### PR TITLE
[fastgltf] Improve support for Conan 2.0 and make it work on CI

### DIFF
--- a/recipes/fastgltf/all/conanfile.py
+++ b/recipes/fastgltf/all/conanfile.py
@@ -1,23 +1,23 @@
 from conan import ConanFile
-from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout
-from conan.tools.files import get
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake, cmake_layout
+from conan.tools.files import get, copy, rmdir
 from conan.tools.build import check_min_cppstd
+from conan.tools.microsoft import check_min_vs, is_msvc
+from conan.errors import ConanInvalidConfiguration
+from conan import Version
+import os
 
 
-required_conan_version = ">=1.59.0"
+required_conan_version = ">=1.53.0"
 
 
-class fastgltf(ConanFile):
+class FastGLTFConan(ConanFile):
     name = "fastgltf"
     license = "MIT"
     url = "https://github.com/conan-io/conan-center-index"
     homepage = "https://github.com/spnda/fastgltf"
     description = "A blazing fast C++17 glTF 2.0 library powered by SIMD."
     topics = ("gltf", "simd", "cpp17")
-
-    # Needed for CMake configurations for dependencies to work
-    generators = "CMakeDeps"
-
     package_type = "library"
     settings = "os", "compiler", "build_type", "arch"
 
@@ -31,6 +31,18 @@ class fastgltf(ConanFile):
         "fPIC": True,
         "enable_small_vector": False,
     }
+
+    @property
+    def _min_cppstd(self):
+        return 17
+
+    @property
+    def _compilers_minimum_version(self):
+        return {
+            "gcc": "7",
+            "clang": "7",
+            "apple-clang": "10",
+        }
 
     def source(self):
         get(self, **self.conan_data["sources"][self.version], strip_root=True)
@@ -47,8 +59,13 @@ class fastgltf(ConanFile):
         cmake_layout(self, src_folder='src')
 
     def validate(self):
-        if self.settings.get_safe("compiler.cppstd"):
-            check_min_cppstd(self, "17")
+        if self.settings.compiler.cppstd:
+            check_min_cppstd(self, self._min_cppstd)
+        check_min_vs(self, 191)
+        if not is_msvc(self):
+            minimum_version = self._compilers_minimum_version.get(str(self.settings.compiler), False)
+            if minimum_version and Version(self.settings.compiler.version) < minimum_version:
+                raise ConanInvalidConfiguration(f"{self.ref} requires C++{self._min_cppstd}, which your compiler does not support.")
 
     def requirements(self):
         self.requires("simdjson/3.1.7")
@@ -56,8 +73,9 @@ class fastgltf(ConanFile):
     def generate(self):
         tc = CMakeToolchain(self)
         tc.variables["FASTGLTF_DOWNLOAD_SIMDJSON"] = False
-        if self.options.enable_small_vector:
-            tc.variables["FASTGLTF_USE_SMALL_VECTOR"] = True
+        tc.variables["FASTGLTF_USE_SMALL_VECTOR"] = self.options.enable_small_vector
+        tc.generate()
+        tc = CMakeDeps(self)
         tc.generate()
 
     def build(self):
@@ -66,8 +84,10 @@ class fastgltf(ConanFile):
         cmake.build()
 
     def package(self):
+        copy(self, "LICENSE.md", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         cmake = CMake(self)
         cmake.install()
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
 
     def package_info(self):
         self.cpp_info.libs = ["fastgltf"]

--- a/recipes/fastgltf/all/test_package/CMakeLists.txt
+++ b/recipes/fastgltf/all/test_package/CMakeLists.txt
@@ -3,6 +3,6 @@ project(test_package LANGUAGES CXX)
 
 find_package(fastgltf REQUIRED CONFIG)
 
-set(CMAKE_CXX_STANDARD 17)
 add_executable(${PROJECT_NAME} test_package.cpp)
-target_link_libraries(${PROJECT_NAME} fastgltf::fastgltf)
+target_link_libraries(${PROJECT_NAME} PRIVATE fastgltf::fastgltf)
+target_compile_features(${PROJECT_NAME} PRIVATE cxx_std_17)

--- a/recipes/fastgltf/all/test_package/conanfile.py
+++ b/recipes/fastgltf/all/test_package/conanfile.py
@@ -4,7 +4,6 @@ from conan.tools.cmake import cmake_layout, CMake
 import os
 
 
-# It will become the standard on Conan 2.x
 class TestPackageConan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "CMakeDeps", "CMakeToolchain", "VirtualRunEnv"

--- a/recipes/fastgltf/all/test_package/test_package.cpp
+++ b/recipes/fastgltf/all/test_package/test_package.cpp
@@ -6,4 +6,5 @@ int main() {
     printf("Version: " FASTGLTF_QUOTE(FASTGLTF_VERSION));
     printf("C++17: " FASTGLTF_QUOTE(FASTGLTF_CPP_17));
     printf("C++20: " FASTGLTF_QUOTE(FASTGLTF_CPP_20));
+    return 0;
 }

--- a/recipes/fastgltf/all/test_v1_package/CMakeLists.txt
+++ b/recipes/fastgltf/all/test_v1_package/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.15)
 project(test_package)
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/recipes/fastgltf/all/test_v1_package/conanfile.py
+++ b/recipes/fastgltf/all/test_v1_package/conanfile.py
@@ -3,7 +3,6 @@ from conan.tools.build import cross_building
 import os
 
 
-# legacy validation with Conan 1.x
 class TestPackageV1Conan(ConanFile):
     settings = "os", "arch", "compiler", "build_type"
     generators = "cmake", "cmake_find_package_multi"


### PR DESCRIPTION
@spnda Thank you for your original contribution. Your recipe needed some adjustments to work on ConanCenterIndex that I pushed in this pull request.

- As it requires C++17, old compilers will not support, so need to validate it
- License file need to be copied always
- CMake files generated by the project should be removed to avoid target errors, users and tests should consume those cmake files generated by Conan only


---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
